### PR TITLE
Implement orchestration layer

### DIFF
--- a/src/apex/__init__.py
+++ b/src/apex/__init__.py
@@ -9,10 +9,24 @@ __email__ = "wave@nibzard.com"
 
 from apex.config import Config
 from apex.types import AgentType, ProjectConfig, SessionState
+from apex.orchestration import (
+    SessionManager,
+    Session,
+    ContinuationManager,
+    OrchestrationEngine,
+    StateStore,
+    EventBus,
+)
 
 __all__ = [
     "Config",
     "AgentType",
     "SessionState",
     "ProjectConfig",
+    "SessionManager",
+    "Session",
+    "ContinuationManager",
+    "OrchestrationEngine",
+    "StateStore",
+    "EventBus",
 ]

--- a/src/apex/orchestration/__init__.py
+++ b/src/apex/orchestration/__init__.py
@@ -1,0 +1,16 @@
+"""Orchestration and continuation utilities."""
+
+from .session import SessionManager, Session
+from .continuation import ContinuationManager
+from .engine import OrchestrationEngine
+from .state import StateStore
+from .events import EventBus
+
+__all__ = [
+    "SessionManager",
+    "Session",
+    "ContinuationManager",
+    "OrchestrationEngine",
+    "StateStore",
+    "EventBus",
+]

--- a/src/apex/orchestration/continuation.py
+++ b/src/apex/orchestration/continuation.py
@@ -1,0 +1,43 @@
+"""Checkpoint and continuation utilities."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import msgpack
+
+
+class ContinuationManager:
+    """Manage checkpoints for pause/resume functionality."""
+
+    def __init__(self, base_path: Path):
+        self.base_path = base_path
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _session_dir(self, session_id: str) -> Path:
+        path = self.base_path / session_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def save_checkpoint(self, session_id: str, state: Dict[str, Any]) -> Path:
+        """Persist a checkpoint for the given session."""
+        session_dir = self._session_dir(session_id)
+        file_path = session_dir / f"{int(time.time())}.msgpack"
+        with open(file_path, "wb") as f:
+            msgpack.pack(state, f)
+        return file_path
+
+    def load_checkpoint(self, session_id: str, checkpoint_file: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+        """Load the latest or specified checkpoint."""
+        session_dir = self._session_dir(session_id)
+        if checkpoint_file is None:
+            checkpoints = sorted(session_dir.glob("*.msgpack"))
+            if not checkpoints:
+                return None
+            checkpoint_file = checkpoints[-1]
+        if not checkpoint_file.exists():
+            return None
+        with open(checkpoint_file, "rb") as f:
+            return msgpack.unpack(f, raw=False)

--- a/src/apex/orchestration/engine.py
+++ b/src/apex/orchestration/engine.py
@@ -1,0 +1,47 @@
+"""Main orchestration engine."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Optional
+
+from apex.types import SessionState
+
+from .events import EventBus
+from .session import SessionManager
+
+
+class OrchestrationEngine:
+    """Execute workflows across agents."""
+
+    def __init__(self, session_manager: SessionManager, event_bus: Optional[EventBus] = None):
+        self.session_manager = session_manager
+        self.event_bus = event_bus or EventBus()
+
+    def run_workflow(self, session_id: str, steps: Iterable[Callable[[], None]]) -> None:
+        """Execute a series of tasks for the given session."""
+        session = self.session_manager.get(session_id)
+        if session is None:
+            raise ValueError("Session not found")
+
+        session.state = SessionState.ACTIVE
+        self.session_manager.update(session)
+        self.event_bus.publish("session_started", {"session_id": session_id})
+
+        for step in steps:
+            step_name = getattr(step, "__name__", "step")
+            self.event_bus.publish("task_started", {"session_id": session_id, "task": step_name})
+            try:
+                step()
+                self.event_bus.publish("task_completed", {"session_id": session_id, "task": step_name})
+            except Exception as exc:  # pylint: disable=broad-except
+                session.state = SessionState.FAILED
+                self.session_manager.update(session)
+                self.event_bus.publish(
+                    "task_failed",
+                    {"session_id": session_id, "task": step_name, "error": str(exc)},
+                )
+                raise
+
+        session.state = SessionState.INACTIVE
+        self.session_manager.update(session)
+        self.event_bus.publish("session_finished", {"session_id": session_id})

--- a/src/apex/orchestration/events.py
+++ b/src/apex/orchestration/events.py
@@ -1,0 +1,53 @@
+"""Event bus implementation."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import lmdb
+import msgpack
+
+
+class EventBus:
+    """Publish and subscribe to events."""
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        self.subscribers: Dict[str, List[Callable[[Dict[str, Any]], None]]] = {}
+        self.env: Optional[lmdb.Environment] = None
+        self.db: Optional[lmdb._Database] = None
+        if storage_path is not None:
+            storage_path.parent.mkdir(parents=True, exist_ok=True)
+            self.env = lmdb.open(str(storage_path), map_size=2 * 1024 * 1024, max_dbs=1)
+            self.db = self.env.open_db(b"events")
+
+    def subscribe(self, event_type: str, handler: Callable[[Dict[str, Any]], None]) -> None:
+        self.subscribers.setdefault(event_type, []).append(handler)
+
+    def _persist(self, event: Dict[str, Any]) -> None:
+        if self.env is None or self.db is None:
+            return
+        with self.env.begin(write=True, db=self.db) as txn:
+            txn.put(uuid.uuid4().hex.encode(), msgpack.packb(event, use_bin_type=True))
+
+    def publish(self, event_type: str, data: Optional[Dict[str, Any]] = None) -> None:
+        event = {
+            "type": event_type,
+            "timestamp": datetime.now().isoformat(),
+            "data": data or {},
+        }
+        self._persist(event)
+        for handler in self.subscribers.get(event_type, []):
+            handler(event)
+
+    def replay(self) -> List[Dict[str, Any]]:
+        if self.env is None or self.db is None:
+            return []
+        events: List[Dict[str, Any]] = []
+        with self.env.begin(db=self.db) as txn:
+            cursor = txn.cursor()
+            for _, value in cursor:
+                events.append(msgpack.unpackb(value, raw=False))
+        return events

--- a/src/apex/orchestration/session.py
+++ b/src/apex/orchestration/session.py
@@ -1,0 +1,81 @@
+"""Session management utilities."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import lmdb
+import msgpack
+from pydantic import BaseModel, Field
+
+from apex.types import ProjectConfig, SessionState
+
+
+class Session(BaseModel):
+    """Represents a single APEX session."""
+
+    session_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    config: ProjectConfig
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    state: SessionState = SessionState.INACTIVE
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class SessionManager:
+    """Manage the lifecycle of APEX sessions."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.mkdir(parents=True, exist_ok=True)
+        # a dedicated LMDB environment for sessions
+        self.env = lmdb.open(
+            str(self.path / "sessions.db"), map_size=2 * 1024 * 1024, max_dbs=1
+        )
+        self.db = self.env.open_db(b"sessions")
+
+    def _serialize(self, session: Session) -> bytes:
+        """Serialize a session to bytes."""
+        return msgpack.packb(session.model_dump(mode="json"), use_bin_type=True)
+
+    def _deserialize(self, data: bytes) -> Session:
+        """Deserialize a session from bytes."""
+        unpacked = msgpack.unpackb(data, raw=False)
+        return Session.model_validate(unpacked)
+
+    def create(self, config: ProjectConfig, metadata: Optional[Dict[str, Any]] = None) -> Session:
+        """Create and persist a new session."""
+        session = Session(config=config, metadata=metadata or {})
+        with self.env.begin(write=True, db=self.db) as txn:
+            txn.put(session.session_id.encode(), self._serialize(session))
+        return session
+
+    def get(self, session_id: str) -> Optional[Session]:
+        """Retrieve a session by ID."""
+        with self.env.begin(db=self.db) as txn:
+            data = txn.get(session_id.encode())
+            if data is None:
+                return None
+            return self._deserialize(data)
+
+    def list_sessions(self) -> List[Session]:
+        """Return all stored sessions."""
+        sessions: List[Session] = []
+        with self.env.begin(db=self.db) as txn:
+            cursor = txn.cursor()
+            for _, value in cursor:
+                sessions.append(self._deserialize(value))
+        return sessions
+
+    def update(self, session: Session) -> None:
+        """Persist an updated session."""
+        with self.env.begin(write=True, db=self.db) as txn:
+            txn.put(session.session_id.encode(), self._serialize(session))
+
+    def delete(self, session_id: str) -> bool:
+        """Delete a session."""
+        with self.env.begin(write=True, db=self.db) as txn:
+            return txn.delete(session_id.encode())
+

--- a/src/apex/orchestration/state.py
+++ b/src/apex/orchestration/state.py
@@ -1,0 +1,43 @@
+"""Persistent state storage using LMDB."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import lmdb
+import msgpack
+
+
+class StateStore:
+    """Simple LMDB-backed key-value store."""
+
+    def __init__(self, path: Path, map_size: int = 2 * 1024 * 1024):
+        self.path = path
+        self.env = lmdb.open(str(self.path), map_size=map_size)
+
+    def _pack(self, value: Any) -> bytes:
+        return msgpack.packb(value, use_bin_type=True)
+
+    def _unpack(self, data: Optional[bytes]) -> Any:
+        if data is None:
+            return None
+        return msgpack.unpackb(data, raw=False)
+
+    def set(self, key: str, value: Any) -> None:
+        with self.env.begin(write=True) as txn:
+            txn.put(key.encode(), self._pack(value))
+
+    def get(self, key: str) -> Any:
+        with self.env.begin() as txn:
+            return self._unpack(txn.get(key.encode()))
+
+    def delete(self, key: str) -> bool:
+        with self.env.begin(write=True) as txn:
+            return txn.delete(key.encode())
+
+    def keys(self) -> Iterable[str]:
+        with self.env.begin() as txn:
+            cursor = txn.cursor()
+            for key, _ in cursor:
+                yield key.decode()

--- a/tests/unit/orchestration/test_continuation.py
+++ b/tests/unit/orchestration/test_continuation.py
@@ -1,0 +1,13 @@
+"""Tests for ContinuationManager."""
+
+from apex.orchestration import ContinuationManager
+
+
+def test_save_and_load_checkpoint(tmp_path):
+    manager = ContinuationManager(tmp_path)
+    state = {"counter": 1}
+
+    path = manager.save_checkpoint("sess", state)
+    loaded = manager.load_checkpoint("sess", path)
+
+    assert loaded == state

--- a/tests/unit/orchestration/test_engine.py
+++ b/tests/unit/orchestration/test_engine.py
@@ -1,0 +1,34 @@
+"""Tests for OrchestrationEngine."""
+
+from apex.orchestration import EventBus, OrchestrationEngine, SessionManager
+from apex.types import ProjectConfig
+
+
+def sample_project() -> ProjectConfig:
+    return ProjectConfig(
+        project_id="p1",
+        name="Engine",
+        description="d",
+        tech_stack=["py"],
+        project_type="lib",
+        features=[],
+    )
+
+
+def test_run_workflow(tmp_path):
+    session_manager = SessionManager(tmp_path)
+    session = session_manager.create(sample_project())
+
+    bus = EventBus()
+    seen = []
+    bus.subscribe("task_completed", lambda e: seen.append(e["data"]["task"]))
+
+    engine = OrchestrationEngine(session_manager, bus)
+
+    def step_a():
+        seen.append("a")
+
+    engine.run_workflow(session.session_id, [step_a])
+
+    assert "a" in seen
+    assert "step_a" in seen

--- a/tests/unit/orchestration/test_events.py
+++ b/tests/unit/orchestration/test_events.py
@@ -1,0 +1,13 @@
+"""Tests for EventBus."""
+
+from apex.orchestration import EventBus
+
+
+def test_publish_and_replay(tmp_path):
+    bus = EventBus(tmp_path / "events.db")
+    bus.publish("test", {"foo": "bar"})
+
+    events = bus.replay()
+    assert len(events) == 1
+    assert events[0]["type"] == "test"
+    assert events[0]["data"]["foo"] == "bar"

--- a/tests/unit/orchestration/test_session.py
+++ b/tests/unit/orchestration/test_session.py
@@ -1,0 +1,38 @@
+"""Tests for SessionManager."""
+
+from apex.orchestration import SessionManager
+from apex.types import ProjectConfig
+
+
+def sample_project() -> ProjectConfig:
+    return ProjectConfig(
+        project_id="proj1",
+        name="Test",
+        description="desc",
+        tech_stack=["python"],
+        project_type="lib",
+        features=["a"],
+    )
+
+
+def test_create_and_get_session(tmp_path):
+    manager = SessionManager(tmp_path)
+    config = sample_project()
+
+    session = manager.create(config)
+    retrieved = manager.get(session.session_id)
+
+    assert retrieved is not None
+    assert retrieved.session_id == session.session_id
+    assert retrieved.config.name == "Test"
+
+
+def test_list_sessions(tmp_path):
+    manager = SessionManager(tmp_path)
+    config = sample_project()
+
+    manager.create(config)
+    manager.create(config)
+
+    sessions = manager.list_sessions()
+    assert len(sessions) == 2

--- a/tests/unit/orchestration/test_state.py
+++ b/tests/unit/orchestration/test_state.py
@@ -1,0 +1,13 @@
+"""Tests for StateStore."""
+
+from apex.orchestration import StateStore
+
+
+def test_set_get_delete(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+
+    store.set("foo", {"bar": 1})
+    assert store.get("foo") == {"bar": 1}
+
+    assert store.delete("foo") is True
+    assert store.get("foo") is None


### PR DESCRIPTION
## Summary
- create `apex.orchestration` package with session, events, state and engine modules
- wire up orchestration utilities in package init
- expose orchestration classes from `apex.__init__`
- add unit tests covering session management, continuation, event bus, engine and state store

## Testing
- `pip install pytest-cov toml pydantic lmdb msgpack typer`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ea00070832093e6de8d02693d4f