### PR TITLE
Add basic agent commands and TUI skeleton

### DIFF
--- a/src/apex/cli/commands.py
+++ b/src/apex/cli/commands.py
@@ -11,6 +11,13 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+# Sub-command groups
+agent_app = typer.Typer(help="Agent management commands")
+memory_app = typer.Typer(help="Memory operations")
+
+app.add_typer(agent_app, name="agent")
+app.add_typer(memory_app, name="memory")
+
 
 @app.command()
 def new(
@@ -24,6 +31,19 @@ def new(
     """Create a new APEX project."""
     typer.echo(f"Creating new project: {project_name}")
     # TODO: Implement project creation
+
+
+@app.command()
+def list() -> None:
+    """List existing APEX projects."""
+    projects_dir = Path("projects")
+    if not projects_dir.exists():
+        typer.echo("No projects found.")
+        raise typer.Exit()
+
+    typer.echo("PROJECT")
+    for project in sorted(p for p in projects_dir.iterdir() if p.is_dir()):
+        typer.echo(project.name)
 
 
 @app.command()
@@ -53,13 +73,35 @@ def start(
 
 
 @app.command()
+def pause() -> None:
+    """Pause running agents."""
+    typer.echo("Pausing agents...")
+    # TODO: Implement pause logic
+
+
+@app.command()
+def resume() -> None:
+    """Resume paused agents."""
+    typer.echo("Resuming agents...")
+    # TODO: Implement resume logic
+
+
+@app.command()
+def stop() -> None:
+    """Stop all running agents."""
+    typer.echo("Stopping agents...")
+    # TODO: Implement stop logic
+
+
+@app.command()
 def tui(
     layout: Optional[str] = typer.Option("dashboard", "--layout", help="TUI layout"),
     theme: Optional[str] = typer.Option("dark", "--theme", help="Color theme"),
 ):
     """Launch TUI interface."""
-    typer.echo("Launching TUI...")
-    # TODO: Implement TUI
+    from apex.tui import DashboardApp
+
+    DashboardApp().run()
 
 
 @app.command()
@@ -78,6 +120,30 @@ def version():
     from apex import __version__
 
     typer.echo(f"APEX v{__version__}")
+
+
+@agent_app.command("list")
+def agent_list() -> None:
+    """Show agent status."""
+    for agent in ["Supervisor", "Coder", "Adversary"]:
+        typer.echo(f"{agent}: inactive")
+
+
+@agent_app.command("restart")
+def agent_restart(agent_name: str) -> None:
+    """Restart agent process."""
+    typer.echo(f"Restarting {agent_name}...")
+    # TODO: Implement restart logic
+
+
+@memory_app.command("show")
+def memory_show(key: Optional[str] = None) -> None:
+    """Display memory contents."""
+    if key is None:
+        typer.echo("Showing memory root")
+    else:
+        typer.echo(f"Showing memory key: {key}")
+    # TODO: Implement memory retrieval
 
 
 def main():

--- a/src/apex/tui/__init__.py
+++ b/src/apex/tui/__init__.py
@@ -1,0 +1,16 @@
+"""TUI interface for APEX."""
+
+from textual.app import App
+from .screens.dashboard import DashboardScreen
+
+
+class DashboardApp(App):
+    """Simple dashboard TUI application."""
+
+    TITLE = "APEX Dashboard"
+
+    def on_mount(self) -> None:  # pragma: no cover - trivial
+        self.push_screen(DashboardScreen())
+
+
+__all__ = ["DashboardApp"]

--- a/src/apex/tui/screens/dashboard.py
+++ b/src/apex/tui/screens/dashboard.py
@@ -1,0 +1,14 @@
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Header, Footer, Static
+
+
+class DashboardScreen(Screen):
+    """Main dashboard screen for APEX."""
+
+    BINDINGS = [("q", "app.quit", "Quit")]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("APEX Dashboard", id="dashboard-title")
+        yield Footer()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,37 @@
+"""Tests for CLI commands."""
+
+from typer.testing import CliRunner
+
+from apex.cli.commands import app
+
+
+runner = CliRunner()
+
+
+def test_version_command() -> None:
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "APEX v" in result.stdout
+
+
+def test_list_no_projects(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "No projects" in result.stdout
+
+
+def test_list_with_project(tmp_path, monkeypatch) -> None:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    (projects / "demo").mkdir()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "demo" in result.stdout
+
+
+def test_agent_list() -> None:
+    result = runner.invoke(app, ["agent", "list"])
+    assert result.exit_code == 0
+    assert "Supervisor" in result.stdout


### PR DESCRIPTION
## Summary
- expand CLI with subcommands for agent management and memory
- add simple list command and session controls
- create skeleton Textual TUI dashboard
- cover new CLI features with unit tests

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ea74ea88320b86e5aea6b8214a5