### PR TITLE
Add process monitoring thread

### DIFF
--- a/src/apex/core/process_manager.py
+++ b/src/apex/core/process_manager.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
+import threading
 
 import psutil
 
@@ -56,21 +57,29 @@ class ProcessManager:
 
     def __init__(self) -> None:
         self.processes: Dict[str, ManagedProcess] = {}
+        self._desired_state: Dict[str, bool] = {}
+        self.restart_events: Dict[str, int] = {}
+        self._monitor_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._monitor_interval = 1.0
 
     def spawn(self, name: str, command: List[str]) -> None:
         """Spawn a new process with given command."""
         proc = ManagedProcess(command)
         proc.start()
         self.processes[name] = proc
+        self._desired_state[name] = True
 
     def stop(self, name: str) -> None:
         """Stop a managed process."""
         if name in self.processes:
+            self._desired_state[name] = False
             self.processes[name].stop()
 
     def restart(self, name: str) -> None:
         """Restart a managed process."""
         if name in self.processes:
+            self._desired_state[name] = True
             self.processes[name].restart()
 
     def health_check(self, name: str) -> bool:
@@ -87,6 +96,31 @@ class ProcessManager:
 
     def shutdown(self) -> None:
         """Stop all processes."""
-        for proc in self.processes.values():
+        for name, proc in self.processes.items():
+            self._desired_state[name] = False
             proc.stop()
         self.processes.clear()
+        self._desired_state.clear()
+
+    def _monitor_loop(self) -> None:
+        while not self._stop_event.is_set():
+            for name, proc in list(self.processes.items()):
+                if self._desired_state.get(name) and not proc.is_running():
+                    proc.restart()
+                    self.restart_events[name] = self.restart_events.get(name, 0) + 1
+            time.sleep(self._monitor_interval)
+
+    def monitor(self, start: bool = True, interval: float = 1.0) -> None:
+        """Start or stop background monitoring."""
+        if start:
+            if self._monitor_thread and self._monitor_thread.is_alive():
+                return
+            self._monitor_interval = interval
+            self._stop_event.clear()
+            self._monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
+            self._monitor_thread.start()
+        else:
+            self._stop_event.set()
+            if self._monitor_thread:
+                self._monitor_thread.join()
+

--- a/tests/unit/core/test_process_manager.py
+++ b/tests/unit/core/test_process_manager.py
@@ -19,3 +19,23 @@ def test_process_lifecycle():
     time.sleep(0.1)
     assert manager.health_check("test") is False
     manager.shutdown()
+
+
+def test_monitor_restart_on_failure():
+    manager = ProcessManager()
+    cmd = [sys.executable, "-c", "import time; time.sleep(5)"]
+    manager.spawn("mon", cmd)
+    manager.monitor(start=True, interval=0.05)
+    time.sleep(0.1)
+
+    proc = manager.processes["mon"].process
+    proc.kill()
+    proc.wait()
+
+    time.sleep(0.2)
+    manager.monitor(start=False)
+
+    assert manager.restart_events.get("mon", 0) >= 1
+    assert manager.health_check("mon") is True
+    manager.shutdown()
+


### PR DESCRIPTION
## Summary
- extend ProcessManager with a background monitor thread
- restart failed processes automatically
- expose `monitor()` to start and stop monitoring
- test restart behaviour on process failure

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684592c15b08832087d4896891cc8ba0