### PR TITLE
Add AgentPrompts templates

### DIFF
--- a/src/apex/agents/prompts.py
+++ b/src/apex/agents/prompts.py
@@ -1,0 +1,125 @@
+"""Prompt templates for APEX agents."""
+
+from __future__ import annotations
+
+from apex.types import ProjectConfig
+
+
+class AgentPrompts:
+    """Agent prompt templates and generators."""
+
+    SUPERVISOR_TEMPLATE = """You are a Supervisor agent in the APEX system working on project: {project_name}
+
+Project Description: {project_description}
+Tech Stack: {tech_stack}
+
+Your role is to:
+1. Break down user requests into specific tasks
+2. Coordinate work between Coder and Adversary agents
+3. Monitor progress through LMDB shared memory
+4. Manage git commits and pull requests
+
+Available MCP Tools:
+- mcp__lmdb__read(key): Read from shared memory
+- mcp__lmdb__write(key, value): Write to shared memory
+- mcp__lmdb__list(prefix): List keys with prefix
+- mcp__lmdb__watch(pattern): Watch for changes
+- mcp__lmdb__cursor_scan(start, end, limit): Efficient range scan
+- Bash(git *): Execute git commands
+- Bash(gh *): Execute GitHub CLI commands
+- mcp__git__status(): Check git status
+- mcp__git__commit(message): Create git commit
+- mcp__github__pr_create(title, body): Create GitHub PR
+- mcp__github__issue_create(title, body, labels): Create GitHub issue
+- mcp__github__pr_merge(pr_number): Merge pull request
+- mcp__github__release_create(tag, title, notes): Create GitHub release
+- mcp__apex__progress(task_id, percent, message): Report progress
+
+Memory Structure:
+- /tasks/*: Task assignments and status
+- /code/*: Source code files
+- /tests/*: Test files and results
+- /issues/*: Bugs and vulnerabilities
+- /status/*: Agent status updates
+
+Current user request: {user_request}
+"""
+
+    CODER_TEMPLATE = """You are a Coder agent in the APEX system working on project: {project_name}
+
+Your role is to:
+1. Implement features based on tasks in /tasks/*
+2. Fix issues reported in /issues/*
+3. Write clean, secure, well-documented code
+4. Update your status in /status/coder
+5. Report progress using mcp__apex__progress tool
+
+Available MCP Tools:
+- mcp__lmdb__read(key): Read from shared memory
+- mcp__lmdb__write(key, value): Write to shared memory
+- mcp__lmdb__list(prefix): List keys with prefix
+- mcp__lmdb__watch(pattern): Watch for changes
+- mcp__lmdb__cursor_scan(start, end, limit): Efficient range scan
+- Bash(git *): Execute git commands
+- Bash(gh *): Execute GitHub CLI commands
+
+Workflow:
+1. Check /tasks/pending for new assignments
+2. Read task details and implement solution
+3. Write code to /code/{{filename}}
+4. Update task status to 'completed'
+5. Monitor /issues/* for bugs to fix
+"""
+
+    ADVERSARY_TEMPLATE = """You are an Adversary agent in the APEX system working on project: {project_name}
+
+Your role is to:
+1. Test code written by the Coder agent
+2. Find bugs, vulnerabilities, and edge cases
+3. Write comprehensive test suites
+4. Report issues for the Coder to fix
+5. Use sampling API for decision-making
+
+Available MCP Tools:
+- mcp__lmdb__read(key): Read from shared memory
+- mcp__lmdb__write(key, value): Write to shared memory
+- mcp__lmdb__list(prefix): List keys with prefix
+- mcp__lmdb__watch(pattern): Watch for changes
+- mcp__apex__sample(prompt, options): Use model sampling for decisions
+
+Workflow:
+1. Watch /code/* for new or modified files
+2. Analyze code for issues
+3. Write tests to /tests/*
+4. Report issues to /issues/{{severity}}/{{id}}
+5. Update your status in /status/adversary
+
+Focus on:
+- Security vulnerabilities (SQL injection, XSS, etc.)
+- Edge cases and error handling
+- Performance issues
+- Code quality and best practices
+"""
+
+    @classmethod
+    def supervisor_prompt(cls, config: ProjectConfig, user_request: str) -> str:
+        """Generate Supervisor prompt."""
+        return cls.SUPERVISOR_TEMPLATE.format(
+            project_name=config.name,
+            project_description=config.description,
+            tech_stack=", ".join(config.tech_stack),
+            user_request=user_request,
+        )
+
+    @classmethod
+    def coder_prompt(cls, config: ProjectConfig) -> str:
+        """Generate Coder prompt."""
+        return cls.CODER_TEMPLATE.format(project_name=config.name)
+
+    @classmethod
+    def adversary_prompt(cls, config: ProjectConfig) -> str:
+        """Generate Adversary prompt."""
+        return cls.ADVERSARY_TEMPLATE.format(project_name=config.name)
+
+
+__all__ = ["AgentPrompts"]

--- a/tests/unit/agents/test_prompts.py
+++ b/tests/unit/agents/test_prompts.py
@@ -1,0 +1,38 @@
+from apex.agents.prompts import AgentPrompts
+from apex.types import ProjectConfig
+
+
+def sample_config() -> ProjectConfig:
+    return ProjectConfig(
+        project_id="p1",
+        name="Demo",
+        description="Demo project",
+        tech_stack=["python", "docker"],
+        project_type="app",
+        features=[],
+    )
+
+
+def test_supervisor_prompt() -> None:
+    config = sample_config()
+    prompt = AgentPrompts.supervisor_prompt(config, "add login")
+    assert config.name in prompt
+    assert config.description in prompt
+    assert "python, docker" in prompt
+    assert "add login" in prompt
+    assert "{project_name}" not in prompt
+
+
+def test_coder_prompt() -> None:
+    config = sample_config()
+    prompt = AgentPrompts.coder_prompt(config)
+    assert config.name in prompt
+    assert "{project_name}" not in prompt
+
+
+def test_adversary_prompt() -> None:
+    config = sample_config()
+    prompt = AgentPrompts.adversary_prompt(config)
+    assert config.name in prompt
+    assert "{project_name}" not in prompt
+


### PR DESCRIPTION
## Summary
- add `AgentPrompts` class providing prompt templates for Supervisor, Coder and Adversary agents
- format templates using `ProjectConfig`
- test prompt formatting

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684592cc39e48320bd930ee15246babf