### PR TITLE
Implement LMDB persistence for StreamParser

### DIFF
--- a/src/apex/core/stream_parser.py
+++ b/src/apex/core/stream_parser.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Optional
+from typing import Callable, Iterable, Iterator, List, Optional
+
+import msgpack
+import uuid
+
+from .lmdb_mcp import LMDBMCP
 
 
 @dataclass
@@ -31,8 +36,20 @@ class ToolCallEvent:
 class StreamParser:
     """Parse streaming JSON lines from Claude CLI."""
 
-    def __init__(self) -> None:
+    def __init__(self, mcp: Optional[LMDBMCP] = None) -> None:
         self.buffer = ""
+        self.mcp = mcp
+        self.filters: List[Callable[[object], bool]] = []
+
+    def add_filter(self, filter_func: Callable[[object], bool]) -> None:
+        """Register an event filter."""
+        self.filters.append(filter_func)
+
+    def _apply_filters(self, event: object) -> bool:
+        for func in self.filters:
+            if not func(event):
+                return False
+        return True
 
     def feed(self, data: str) -> Iterator[object]:
         """Feed data into the parser and yield events."""
@@ -48,15 +65,44 @@ class StreamParser:
                 continue
             event_type = payload.get("type")
             if event_type == "system":
-                yield SystemEvent(payload)
+                event = SystemEvent(payload)
             elif event_type == "assistant":
-                yield AssistantEvent(payload)
+                event = AssistantEvent(payload)
             elif event_type == "tool":
-                yield ToolCallEvent(payload)
+                event = ToolCallEvent(payload)
             else:
-                yield payload
+                event = payload
+            if self._apply_filters(event):
+                yield event
 
     def parse_lines(self, lines: Iterable[str]) -> Iterator[object]:
         """Convenience method to parse an iterable of lines."""
         for line in lines:
             yield from self.feed(line + "\n")
+
+    def store_event(self, event: object) -> None:
+        """Persist an event to LMDB if configured."""
+        if self.mcp is None:
+            return
+
+        if isinstance(event, (SystemEvent, AssistantEvent, ToolCallEvent)):
+            payload = event.content
+        else:
+            payload = event  # type: ignore[assignment]
+
+        session_id = payload.get("session_id")
+        if session_id is not None:
+            key = f"/sessions/{session_id}/events/{uuid.uuid4().hex}"
+            self.mcp.write(key, msgpack.packb(payload, use_bin_type=True))
+
+        agent_id = payload.get("agent_id")
+        if isinstance(event, AssistantEvent) and agent_id is not None:
+            message = payload.get("message", payload)
+            key = f"/agents/{agent_id}/messages/{uuid.uuid4().hex}"
+            self.mcp.write(key, msgpack.packb(message, use_bin_type=True))
+
+        if isinstance(event, ToolCallEvent):
+            tool_id = payload.get("tool_id")
+            if tool_id is not None:
+                key = f"/tools/calls/{tool_id}"
+                self.mcp.write(key, msgpack.packb(payload, use_bin_type=True))

--- a/tests/unit/core/test_stream_parser.py
+++ b/tests/unit/core/test_stream_parser.py
@@ -1,6 +1,8 @@
 """Tests for StreamParser."""
 
-from apex.core import StreamParser, SystemEvent, AssistantEvent, ToolCallEvent
+import msgpack
+
+from apex.core import LMDBMCP, StreamParser, SystemEvent, AssistantEvent, ToolCallEvent
 
 
 def test_parse_lines():
@@ -14,3 +16,30 @@ def test_parse_lines():
     assert isinstance(events[0], SystemEvent)
     assert isinstance(events[1], AssistantEvent)
     assert isinstance(events[2], ToolCallEvent)
+
+
+def test_event_persistence(tmp_path):
+    mcp = LMDBMCP(tmp_path / "db")
+    parser = StreamParser(mcp)
+    lines = [
+        '{"type": "system", "session_id": "s1", "agent_id": "a1"}',
+        '{"type": "assistant", "session_id": "s1", "agent_id": "a1", "message": {"text": "hi"}}',
+        '{"type": "tool", "session_id": "s1", "agent_id": "a1", "tool_id": "t1"}',
+    ]
+    events = list(parser.parse_lines(lines))
+    for e in events:
+        parser.store_event(e)
+
+    keys = mcp.list_keys()
+    session_keys = [k for k in keys if k.startswith("/sessions/s1/events/")]
+    agent_keys = [k for k in keys if k.startswith("/agents/a1/messages/")]
+
+    assert len(session_keys) == 3
+    assert len(agent_keys) == 1
+    assert "/tools/calls/t1" in keys
+
+    # Validate stored message content
+    data = mcp.read(agent_keys[0])
+    assert data is not None
+    message = msgpack.unpackb(data, raw=False)
+    assert message["text"] == "hi"


### PR DESCRIPTION
## Summary
- extend StreamParser to accept an LMDBMCP instance
- add event filtering hooks and implement `store_event`
- test storing events in LMDB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684592c6fb2c832092666418d017887d