### PR TITLE
Remove runtime AgentType import

### DIFF
--- a/src/apex/agents/prompts.py
+++ b/src/apex/agents/prompts.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from apex.types import ProjectConfig
+
+if TYPE_CHECKING:
+    from apex.types import AgentType
 
 
 class AgentPrompts:
@@ -136,8 +141,6 @@ Focus on:
             Generated prompt string
 
         """
-        from apex.types import AgentType
-
         if agent_type == AgentType.SUPERVISOR:
             return cls.supervisor_prompt(config, user_request)
         elif agent_type == AgentType.CODER:


### PR DESCRIPTION
## Summary
- handle `AgentType` import only at type-check time
- cleanup of `generate_prompt` logic

## Testing
- `pre-commit run ruff --files src/apex/agents/prompts.py` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0a123508320ad0e975fb28deab2